### PR TITLE
Authlib injector, local auth server and ely by accounts support

### DIFF
--- a/api/logic/AuthServer.cpp
+++ b/api/logic/AuthServer.cpp
@@ -9,11 +9,16 @@ AuthServer::AuthServer(QObject *parent) : QObject(parent)
 
   connect(m_tcpServer.get(), &QTcpServer::newConnection, this, &AuthServer::newConnection);
 
-  if (!m_tcpServer->listen(QHostAddress::Any, 6000))
+  if (!m_tcpServer->listen(QHostAddress::LocalHost))
   {
     // TODO: think about stop launching when server start fails 
     qCritical() << "Auth server start failed";
   }
+}
+
+quint16 AuthServer::port()
+{
+  return m_tcpServer->serverPort();
 }
 
 void AuthServer::newConnection()

--- a/api/logic/AuthServer.cpp
+++ b/api/logic/AuthServer.cpp
@@ -54,12 +54,20 @@ void AuthServer::newConnection()
               responseStatusCode = 404;
             }
 
-            if(responseBody.length() != 0){
-              responseHeaders << ((QString)"Content-Length: %1").arg(responseBody.length());
+            QString responseStatusText = "Internal Server Error";
+            if (responseStatusCode == 200)
+              responseStatusText = "OK";
+            else if (responseStatusCode == 204)
+              responseStatusText = "No Content";
+            else if (responseStatusCode == 404)
+              responseStatusText = "Not Found";
+
+            if (responseBody.length() != 0)
+            {
+              responseHeaders << ((QString) "Content-Length: %1").arg(responseBody.length());
             }
 
-
-            tcpSocket->write(((QString)"HTTP/1.1 %1 OK\r\nConnection: keep-alive\r\n").arg(responseStatusCode).toUtf8());
+            tcpSocket->write(((QString) "HTTP/1.1 %1 %2\r\nConnection: keep-alive\r\n").arg(responseStatusCode).arg(responseStatusText).toUtf8());
             tcpSocket->write(responseHeaders.join("\r\n").toUtf8());
             tcpSocket->write("\r\n\r\n");
             tcpSocket->write(responseBody.toUtf8());

--- a/api/logic/AuthServer.cpp
+++ b/api/logic/AuthServer.cpp
@@ -1,0 +1,66 @@
+#include "AuthServer.h"
+
+#include <QDebug>
+#include <QTcpSocket>
+
+AuthServer::AuthServer(QObject *parent) : QObject(parent)
+{
+  m_tcpServer.reset(new QTcpServer(this));
+
+  connect(m_tcpServer.get(), &QTcpServer::newConnection, this, &AuthServer::newConnection);
+
+  if (!m_tcpServer->listen(QHostAddress::Any, 6000))
+  {
+    // TODO: think about stop launching when server start fails 
+    qCritical() << "Auth server start failed";
+  }
+}
+
+void AuthServer::newConnection()
+{
+  QTcpSocket *tcpSocket = m_tcpServer->nextPendingConnection();
+
+  connect(tcpSocket, &QTcpSocket::readyRead, this, [tcpSocket]()
+          {
+            // Not the best way to process queries, but it just works
+            QString rawRequest = tcpSocket->readAll().data();
+            QStringList requestLines = rawRequest.split("\r\n");
+            QString requestPath = requestLines[0].split(" ")[1];
+
+            int responseStatusCode = 500;
+            QString responseBody = "";
+            QStringList responseHeaders;
+
+            responseHeaders << "Connection: keep-alive";
+
+            if (requestPath == "/")
+            {
+              responseBody = "{\"Status\":\"OK\",\"Runtime-Mode\":\"productionMode\",\"Application-Author\":\"Mojang Web Force\",\"Application-Description\":\"Mojang Public API.\",\"Specification-Version\":\"3.58.0\",\"Application-Name\":\"yggdrasil.accounts.restlet.server.public\",\"Implementation-Version\":\"3.58.0_build194\",\"Application-Owner\":\"Mojang\"}";
+              responseStatusCode = 200;
+              responseHeaders << "Content-Type: application/json; charset=utf-8";
+            }
+            else if (requestPath == "/sessionserver/session/minecraft/join" || requestPath == "/sessionserver/session/minecraft/hasJoined")
+            {
+              responseStatusCode = 204;
+            }
+            else
+            {
+              responseBody = "Not found";
+              responseStatusCode = 404;
+            }
+
+            if(responseBody.length() != 0){
+              responseHeaders << ((QString)"Content-Length: %1").arg(responseBody.length());
+            }
+
+
+            tcpSocket->write(((QString)"HTTP/1.1 %1 OK\r\nConnection: keep-alive\r\n").arg(responseStatusCode).toUtf8());
+            tcpSocket->write(responseHeaders.join("\r\n").toUtf8());
+            tcpSocket->write("\r\n\r\n");
+            tcpSocket->write(responseBody.toUtf8());
+          });
+  connect(tcpSocket, &QTcpSocket::disconnected, this, [tcpSocket]()
+          {
+            tcpSocket->close();
+          });
+}

--- a/api/logic/AuthServer.h
+++ b/api/logic/AuthServer.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include <QString>
+#include <QTcpServer>
+#include "settings/SettingsObject.h"
+#include "multimc_logic_export.h"
+
+class MULTIMC_LOGIC_EXPORT AuthServer: public QObject
+{
+public:
+  explicit AuthServer(QObject *parent = 0);
+
+private:
+  void newConnection();
+  
+private:
+  std::shared_ptr<QTcpServer> m_tcpServer;
+};

--- a/api/logic/AuthServer.h
+++ b/api/logic/AuthServer.h
@@ -10,6 +10,8 @@ class MULTIMC_LOGIC_EXPORT AuthServer: public QObject
 public:
   explicit AuthServer(QObject *parent = 0);
 
+  quint16 port();
+
 private:
   void newConnection();
   

--- a/api/logic/BaseInstance.h
+++ b/api/logic/BaseInstance.h
@@ -148,7 +148,7 @@ public:
 
     /// returns a valid launcher (task container)
     virtual shared_qobject_ptr<LaunchTask> createLaunchTask(
-            AuthSessionPtr account, MinecraftServerTargetPtr serverToJoin) = 0;
+        AuthSessionPtr account, MinecraftServerTargetPtr serverToJoin, quint16 localAuthServerPort) = 0;
 
     /// returns the current launch task (if any)
     shared_qobject_ptr<LaunchTask> getLaunchTask();

--- a/api/logic/CMakeLists.txt
+++ b/api/logic/CMakeLists.txt
@@ -4,6 +4,8 @@ include (UnitTest)
 
 set(CORE_SOURCES
     # LOGIC - Base classes and infrastructure
+    AuthServer.h
+    AuthServer.cpp
     BaseInstaller.h
     BaseInstaller.cpp
     BaseVersionList.h

--- a/api/logic/CMakeLists.txt
+++ b/api/logic/CMakeLists.txt
@@ -246,6 +246,8 @@ set(MINECRAFT_SOURCES
     minecraft/launch/ReconstructAssets.h
     minecraft/launch/ScanModFolders.cpp
     minecraft/launch/ScanModFolders.h
+    minecraft/launch/InjectAuthlib.cpp
+    minecraft/launch/InjectAuthlib.h
 
     minecraft/legacy/LegacyModList.h
     minecraft/legacy/LegacyModList.cpp

--- a/api/logic/Env.cpp
+++ b/api/logic/Env.cpp
@@ -92,6 +92,7 @@ void Env::initHttpMetaCache()
     m_metacache->addBase("asset_objects", QDir("assets/objects").absolutePath());
     m_metacache->addBase("versions", QDir("versions").absolutePath());
     m_metacache->addBase("libraries", QDir("libraries").absolutePath());
+    m_metacache->addBase("injectors", QDir("injectors").absolutePath());
     m_metacache->addBase("minecraftforge", QDir("mods/minecraftforge").absolutePath());
     m_metacache->addBase("fmllibs", QDir("mods/minecraftforge/libs").absolutePath());
     m_metacache->addBase("liteloader", QDir("mods/liteloader").absolutePath());

--- a/api/logic/NullInstance.h
+++ b/api/logic/NullInstance.h
@@ -27,7 +27,7 @@ public:
     {
         return instanceRoot();
     };
-    shared_qobject_ptr<LaunchTask> createLaunchTask(AuthSessionPtr, MinecraftServerTargetPtr) override
+    shared_qobject_ptr<LaunchTask> createLaunchTask(AuthSessionPtr, MinecraftServerTargetPtr, quint16) override
     {
         return nullptr;
     }

--- a/api/logic/minecraft/MinecraftInstance.cpp
+++ b/api/logic/minecraft/MinecraftInstance.cpp
@@ -928,8 +928,6 @@ shared_qobject_ptr<LaunchTask> MinecraftInstance::createLaunchTask(AuthSessionPt
         process->appendStep(step);
     }
 
-    // download authlib
-
     {
         // actually launch the game
         auto method = launchMethod();

--- a/api/logic/minecraft/MinecraftInstance.cpp
+++ b/api/logic/minecraft/MinecraftInstance.cpp
@@ -23,6 +23,7 @@
 #include "minecraft/launch/ClaimAccount.h"
 #include "minecraft/launch/ReconstructAssets.h"
 #include "minecraft/launch/ScanModFolders.h"
+#include "minecraft/launch/InjectAuthlib.h"
 #include "java/launch/CheckJava.h"
 #include "java/JavaUtils.h"
 #include "meta/Index.h"
@@ -50,7 +51,7 @@ class OrSetting : public Setting
     Q_OBJECT
 public:
     OrSetting(QString id, std::shared_ptr<Setting> a, std::shared_ptr<Setting> b)
-    :Setting({id}, false), m_a(a), m_b(b)
+        :Setting({id}, false), m_a(a), m_b(b)
     {
     }
     virtual QVariant get() const
@@ -297,6 +298,8 @@ QStringList MinecraftInstance::javaArguments() const
 {
     QStringList args;
 
+    args.append(m_injector->javaArg);
+
     // custom args go first. we want to override them if we have our own here.
     args.append(extraArguments());
 
@@ -401,7 +404,7 @@ static QString replaceTokensIn(QString text, QMap<QString, QString> with)
 }
 
 QStringList MinecraftInstance::processMinecraftArgs(
-        AuthSessionPtr session, MinecraftServerTargetPtr serverToJoin) const
+    AuthSessionPtr session, MinecraftServerTargetPtr serverToJoin) const
 {
     auto profile = m_components->getProfile();
     QString args_pattern = profile->getMinecraftArguments();
@@ -481,9 +484,9 @@ QString MinecraftInstance::createLaunchScript(AuthSessionPtr session, MinecraftS
 
     // generic minecraft params
     for (auto param : processMinecraftArgs(
-            session,
-            nullptr /* When using a launch script, the server parameters are handled by it*/
-    ))
+             session,
+             nullptr /* When using a launch script, the server parameters are handled by it*/
+             ))
     {
         launchScript += "param " + param + "\n";
     }
@@ -601,10 +604,10 @@ QStringList MinecraftInstance::verboseDescription(AuthSessionPtr session, Minecr
             out << QString("%1:").arg(label);
             auto modList = model.allMods();
             std::sort(modList.begin(), modList.end(), [](Mod &a, Mod &b) {
-                auto aName = a.filename().completeBaseName();
-                auto bName = b.filename().completeBaseName();
-                return aName.localeAwareCompare(bName) < 0;
-            });
+                          auto aName = a.filename().completeBaseName();
+                          auto bName = b.filename().completeBaseName();
+                          return aName.localeAwareCompare(bName) < 0;
+                      });
             for(auto & mod: modList)
             {
                 if(mod.type() == Mod::MOD_FOLDER)
@@ -741,12 +744,12 @@ MessageLevel::Enum MinecraftInstance::guessLevel(const QString &line, MessageLev
         return MessageLevel::Fatal;
     //NOTE: this diverges from the real regexp. no unicode, the first section is + instead of *
     static const QString javaSymbol = "([a-zA-Z_$][a-zA-Z\\d_$]*\\.)+[a-zA-Z_$][a-zA-Z\\d_$]*";
-    if (line.contains("Exception in thread")
+        if (line.contains("Exception in thread")
         || line.contains(QRegularExpression("\\s+at " + javaSymbol))
         || line.contains(QRegularExpression("Caused by: " + javaSymbol))
         || line.contains(QRegularExpression("([a-zA-Z_$][a-zA-Z\\d_$]*\\.)+[a-zA-Z_$]?[a-zA-Z\\d_$]*(Exception|Error|Throwable)"))
         || line.contains(QRegularExpression("... \\d+ more$"))
-        )
+        )        
         return MessageLevel::Error;
     return level;
 }
@@ -810,14 +813,14 @@ shared_qobject_ptr<Task> MinecraftInstance::createUpdateTask(Net::Mode mode)
 {
     switch (mode)
     {
-        case Net::Mode::Offline:
-        {
-            return shared_qobject_ptr<Task>(new MinecraftLoadAndCheck(this));
-        }
-        case Net::Mode::Online:
-        {
-            return shared_qobject_ptr<Task>(new MinecraftUpdate(this));
-        }
+    case Net::Mode::Offline:
+    {
+        return shared_qobject_ptr<Task>(new MinecraftLoadAndCheck(this));
+    }
+    case Net::Mode::Online:
+    {
+        return shared_qobject_ptr<Task>(new MinecraftUpdate(this));
+    }
     }
     return nullptr;
 }
@@ -913,6 +916,13 @@ shared_qobject_ptr<LaunchTask> MinecraftInstance::createLaunchTask(AuthSessionPt
     {
         process->appendStep(new ReconstructAssets(pptr));
     }
+
+    // authlib patch
+    {
+        process->appendStep(new InjectAuthlib(pptr, &m_injector));
+    }
+
+    // download authlib
 
     {
         // actually launch the game

--- a/api/logic/minecraft/MinecraftInstance.cpp
+++ b/api/logic/minecraft/MinecraftInstance.cpp
@@ -825,7 +825,7 @@ shared_qobject_ptr<Task> MinecraftInstance::createUpdateTask(Net::Mode mode)
     return nullptr;
 }
 
-shared_qobject_ptr<LaunchTask> MinecraftInstance::createLaunchTask(AuthSessionPtr session, MinecraftServerTargetPtr serverToJoin)
+shared_qobject_ptr<LaunchTask> MinecraftInstance::createLaunchTask(AuthSessionPtr session, MinecraftServerTargetPtr serverToJoin, quint16 localAuthServerPort)
 {
     // FIXME: get rid of shared_from_this ...
     auto process = LaunchTask::create(std::dynamic_pointer_cast<MinecraftInstance>(shared_from_this()));
@@ -919,7 +919,9 @@ shared_qobject_ptr<LaunchTask> MinecraftInstance::createLaunchTask(AuthSessionPt
 
     // authlib patch
     {
-        process->appendStep(new InjectAuthlib(pptr, &m_injector));
+        auto step = new InjectAuthlib(pptr, &m_injector);
+        step->setAuthServer(((QString)"http://localhost:%1").arg(localAuthServerPort));
+        process->appendStep(step);
     }
 
     // download authlib

--- a/api/logic/minecraft/MinecraftInstance.cpp
+++ b/api/logic/minecraft/MinecraftInstance.cpp
@@ -918,6 +918,7 @@ shared_qobject_ptr<LaunchTask> MinecraftInstance::createLaunchTask(AuthSessionPt
     }
 
     // authlib patch
+    if (session->m_accountPtr->loginType() == "dummy")
     {
         auto step = new InjectAuthlib(pptr, &m_injector);
         step->setAuthServer(((QString)"http://localhost:%1").arg(localAuthServerPort));

--- a/api/logic/minecraft/MinecraftInstance.cpp
+++ b/api/logic/minecraft/MinecraftInstance.cpp
@@ -918,10 +918,13 @@ shared_qobject_ptr<LaunchTask> MinecraftInstance::createLaunchTask(AuthSessionPt
     }
 
     // authlib patch
-    if (session->m_accountPtr->loginType() == "dummy")
+    if (session->m_accountPtr->loginType() != "mojang")
     {
         auto step = new InjectAuthlib(pptr, &m_injector);
-        step->setAuthServer(((QString)"http://localhost:%1").arg(localAuthServerPort));
+        if(session->m_accountPtr->loginType() == "dummy")
+            step->setAuthServer(((QString)"http://localhost:%1").arg(localAuthServerPort));
+        else if(session->m_accountPtr->loginType() == "elyby")
+            step->setAuthServer(((QString) "ely.by").arg(localAuthServerPort));
         process->appendStep(step);
     }
 

--- a/api/logic/minecraft/MinecraftInstance.h
+++ b/api/logic/minecraft/MinecraftInstance.h
@@ -6,6 +6,7 @@
 #include <QDir>
 #include "multimc_logic_export.h"
 #include "minecraft/launch/MinecraftServerTarget.h"
+#include "minecraft/launch/InjectAuthlib.h"
 
 class ModFolderModel;
 class WorldList;
@@ -128,6 +129,7 @@ protected: // data
     mutable std::shared_ptr<ModFolderModel> m_texture_pack_list;
     mutable std::shared_ptr<WorldList> m_world_list;
     mutable std::shared_ptr<GameOptions> m_game_options;
+    mutable std::shared_ptr<AuthlibInjector> m_injector;
 };
 
 typedef std::shared_ptr<MinecraftInstance> MinecraftInstancePtr;

--- a/api/logic/minecraft/MinecraftInstance.h
+++ b/api/logic/minecraft/MinecraftInstance.h
@@ -78,7 +78,7 @@ public:
 
     //////  Launch stuff //////
     shared_qobject_ptr<Task> createUpdateTask(Net::Mode mode) override;
-    shared_qobject_ptr<LaunchTask> createLaunchTask(AuthSessionPtr account, MinecraftServerTargetPtr serverToJoin) override;
+    shared_qobject_ptr<LaunchTask> createLaunchTask(AuthSessionPtr account, MinecraftServerTargetPtr serverToJoin, quint16 localAuthServerPort) override;
     QStringList extraArguments() const override;
     QStringList verboseDescription(AuthSessionPtr session, MinecraftServerTargetPtr serverToJoin) override;
     QList<Mod> getJarMods() const;

--- a/api/logic/minecraft/auth/MojangAccount.cpp
+++ b/api/logic/minecraft/auth/MojangAccount.cpp
@@ -202,7 +202,7 @@ std::shared_ptr<YggdrasilTask> MojangAccount::login(AuthSessionPtr session, QStr
             // TODO: Proper profile support (idk how)
             auto dummyProfile = AccountProfile();
             dummyProfile.name = m_username;
-            dummyProfile.id = "-";
+            dummyProfile.id = QUuid::createUuid().toString().remove(QRegExp("[{}]"));
             m_profiles.append(dummyProfile);
             m_currentProfile = 0;
         }

--- a/api/logic/minecraft/auth/MojangAccount.cpp
+++ b/api/logic/minecraft/auth/MojangAccount.cpp
@@ -28,6 +28,8 @@
 
 #include <QDebug>
 
+#include <BuildConfig.h>
+
 MojangAccountPtr MojangAccount::loadFromJson(const QJsonObject &object)
 {
     // The JSON object must at least have a username for it to be valid.
@@ -148,7 +150,7 @@ QJsonObject MojangAccount::saveToJson() const
 bool MojangAccount::setLoginType(const QString &loginType)
 {
     // TODO: Implement a cleaner validity check
-    if (loginType == "mojang" or loginType == "dummy")
+    if (loginType == "mojang" || loginType == "dummy" || loginType == "elyby")
     {
         m_loginType = loginType;
         return true;
@@ -182,6 +184,14 @@ AccountStatus MojangAccount::accountStatus() const
         return NotVerified;
     else
         return Verified;
+}
+
+QString MojangAccount::authEndpoint() const
+{
+    if(m_loginType == "elyby")
+        return BuildConfig.AUTH_BASE_ELYBY;
+
+    return BuildConfig.AUTH_BASE_MOJANG;
 }
 
 std::shared_ptr<YggdrasilTask> MojangAccount::login(AuthSessionPtr session, QString password)

--- a/api/logic/minecraft/auth/MojangAccount.h
+++ b/api/logic/minecraft/auth/MojangAccount.h
@@ -141,6 +141,8 @@ public: /* queries */
     //! Returns whether the account is NotVerified, Verified or Online
     AccountStatus accountStatus() const;
 
+    QString authEndpoint() const;
+
 signals:
     /**
      * This signal is emitted when the account changes
@@ -151,7 +153,7 @@ signals:
 
 protected: /* variables */
     // Authentication system used.
-    // Usable values: "mojang", "dummy"
+    // Usable values: "mojang", "dummy", "elyby"
     QString m_loginType;
 
     // Username taken by account.

--- a/api/logic/minecraft/auth/YggdrasilTask.cpp
+++ b/api/logic/minecraft/auth/YggdrasilTask.cpp
@@ -25,8 +25,6 @@
 
 #include <Env.h>
 
-#include <BuildConfig.h>
-
 #include <QDebug>
 
 YggdrasilTask::YggdrasilTask(MojangAccount *account, QObject *parent)
@@ -42,8 +40,9 @@ void YggdrasilTask::executeTask()
     // Get the content of the request we're going to send to the server.
     QJsonDocument doc(getRequestContent());
 
-    QUrl reqUrl(BuildConfig.AUTH_BASE + getEndpoint());
-    QNetworkRequest netRequest(reqUrl);
+    QUrl reqUrl(m_account->authEndpoint() + getEndpoint());
+    qDebug() << m_account->authEndpoint() + getEndpoint();
+                                                QNetworkRequest netRequest(reqUrl);
     netRequest.setHeader(QNetworkRequest::ContentTypeHeader, "application/json");
 
     QByteArray requestData = doc.toJson();

--- a/api/logic/minecraft/launch/InjectAuthlib.cpp
+++ b/api/logic/minecraft/launch/InjectAuthlib.cpp
@@ -1,0 +1,174 @@
+/* Copyright 2013-2021 MultiMC Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "InjectAuthlib.h"
+#include <launch/LaunchTask.h>
+#include <minecraft/MinecraftInstance.h>
+#include <FileSystem.h>
+#include <Env.h>
+InjectAuthlib::InjectAuthlib(LaunchTask *parent, AuthlibInjectorPtr* injector) : LaunchStep(parent)
+{
+  m_injector = injector;
+}
+
+void InjectAuthlib::executeTask()
+{
+
+  if (m_aborted)
+  {
+    emitFailed(tr("Task aborted."));
+    return;
+  }
+
+  auto latestVersionInfo = QString("https://authlib-injector.yushi.moe/artifact/latest.json");
+  auto netJob = new NetJob("Injector versions info download");
+  MetaEntryPtr entry = ENV.metacache()->resolveEntry("injectors", "version.json");
+  entry->setStale(true);
+  auto task = Net::Download::makeCached(QUrl(latestVersionInfo), entry);
+  netJob->addNetAction(task);
+
+  jobPtr.reset(netJob);
+  QObject::connect(netJob, &NetJob::succeeded, this, &InjectAuthlib::onVersionDownloadSucceeded);
+  QObject::connect(netJob, &NetJob::failed, this, &InjectAuthlib::onDownloadFailed);
+  jobPtr->start();
+}
+
+void InjectAuthlib::onVersionDownloadSucceeded()
+{
+
+  QByteArray data;
+  try
+  {
+    data = FS::read(QDir("injectors").absoluteFilePath("version.json"));
+  }
+  catch (const Exception &e)
+  {
+    qCritical() << "Translations Download Failed: index file not readable";
+    jobPtr.reset();
+    emitFailed("Error while parsing JSON response from InjectorEndpoint");
+    return;
+  }
+
+  qDebug() << "Version got\n";
+  QJsonParseError parse_error;
+  QJsonDocument doc = QJsonDocument::fromJson(data, &parse_error);
+  if (parse_error.error != QJsonParseError::NoError)
+  {
+    qCritical() << "Error while parsing JSON response from InjectorEndpoint at " << parse_error.offset << " reason: " << parse_error.errorString();
+    qCritical() << data;
+    jobPtr.reset();
+    emitFailed("Error while parsing JSON response from InjectorEndpoint");
+    return;
+  }
+
+  if (!doc.isObject())
+  {
+    qCritical() << "Error while parsing JSON response from InjectorEndpoint root is not object";
+    qCritical() << data;
+    jobPtr.reset();
+    emitFailed("Error while parsing JSON response from InjectorEndpoint");
+    return;
+  }
+
+  auto downloadUrlValue = doc["download_url"];
+  if (!downloadUrlValue.isString())
+  {
+    qCritical() << "Error while parsing JSON response from InjectorEndpoint download url is not string";
+    qCritical() << data;
+    jobPtr.reset();
+    emitFailed("Error while parsing JSON response from InjectorEndpoint");
+    return;
+  }
+
+  QString downloadUrl = downloadUrlValue.toString();
+
+  QFileInfo fi(downloadUrl);
+  m_versionName = fi.fileName();
+
+  qDebug() << "Authlib injector version:" << m_versionName;
+
+  auto netJob = new NetJob("Injector download");
+  MetaEntryPtr entry = ENV.metacache()->resolveEntry("injectors", m_versionName);
+  entry->setStale(true);
+  auto task = Net::Download::makeCached(QUrl(downloadUrl), entry);
+  netJob->addNetAction(task);
+
+  jobPtr.reset(netJob);
+  QObject::connect(netJob, &NetJob::succeeded, this, &InjectAuthlib::onDownloadSucceeded);
+  QObject::connect(netJob, &NetJob::failed, this, &InjectAuthlib::onDownloadFailed);
+  jobPtr->start();
+}
+
+void InjectAuthlib::onDownloadSucceeded()
+{
+  QString injector = QString("-javaagent:%1=%2").arg(QDir("injectors").absoluteFilePath(m_versionName)).arg("http://localhost:8000");
+
+  qDebug()
+      << "Injecting " << injector;
+  auto inj = new AuthlibInjector(injector);
+  qDebug() << "aAA" << inj;
+  m_injector->reset(inj);
+
+  jobPtr.reset();
+  emitSucceeded();
+}
+
+void InjectAuthlib::onDownloadFailed(QString reason)
+{
+  jobPtr.reset();
+  emitFailed(reason);
+}
+
+void InjectAuthlib::proceed()
+{
+}
+
+// void InjectAuthlib::updateFinished()
+// {
+//   // if (m_updateTask->wasSuccessful())
+//   // {
+//   //   m_updateTask.reset();
+//   //   emitSucceeded();
+//   // }
+//   // else
+//   // {
+//   //   QString reason = tr("Instance update failed because: %1\n\n").arg(m_updateTask->failReason());
+//   //   m_updateTask.reset();
+//   //   emit logLine(reason, MessageLevel::Fatal);
+//   //   emitFailed(reason);
+//   // }
+// }
+
+bool InjectAuthlib::canAbort() const
+{
+  if (jobPtr)
+  {
+    return jobPtr->canAbort();
+  }
+  return true;
+}
+
+bool InjectAuthlib::abort()
+{
+  m_aborted = true;
+  if (jobPtr)
+  {
+    if (jobPtr->canAbort())
+    {
+      return jobPtr->abort();
+    }
+  }
+  return true;
+}

--- a/api/logic/minecraft/launch/InjectAuthlib.cpp
+++ b/api/logic/minecraft/launch/InjectAuthlib.cpp
@@ -113,7 +113,7 @@ void InjectAuthlib::onVersionDownloadSucceeded()
 
 void InjectAuthlib::onDownloadSucceeded()
 {
-  QString injector = QString("-javaagent:%1=%2").arg(QDir("injectors").absoluteFilePath(m_versionName)).arg("http://localhost:8000");
+  QString injector = QString("-javaagent:%1=%2").arg(QDir("injectors").absoluteFilePath(m_versionName)).arg("http://localhost:6000");
 
   qDebug()
       << "Injecting " << injector;

--- a/api/logic/minecraft/launch/InjectAuthlib.cpp
+++ b/api/logic/minecraft/launch/InjectAuthlib.cpp
@@ -61,7 +61,6 @@ void InjectAuthlib::onVersionDownloadSucceeded()
     return;
   }
 
-  qDebug() << "Version got\n";
   QJsonParseError parse_error;
   QJsonDocument doc = QJsonDocument::fromJson(data, &parse_error);
   if (parse_error.error != QJsonParseError::NoError)
@@ -118,7 +117,6 @@ void InjectAuthlib::onDownloadSucceeded()
   qDebug()
       << "Injecting " << injector;
   auto inj = new AuthlibInjector(injector);
-  qDebug() << "aAA" << inj;
   m_injector->reset(inj);
 
   jobPtr.reset();
@@ -134,22 +132,6 @@ void InjectAuthlib::onDownloadFailed(QString reason)
 void InjectAuthlib::proceed()
 {
 }
-
-// void InjectAuthlib::updateFinished()
-// {
-//   // if (m_updateTask->wasSuccessful())
-//   // {
-//   //   m_updateTask.reset();
-//   //   emitSucceeded();
-//   // }
-//   // else
-//   // {
-//   //   QString reason = tr("Instance update failed because: %1\n\n").arg(m_updateTask->failReason());
-//   //   m_updateTask.reset();
-//   //   emit logLine(reason, MessageLevel::Fatal);
-//   //   emitFailed(reason);
-//   // }
-// }
 
 bool InjectAuthlib::canAbort() const
 {

--- a/api/logic/minecraft/launch/InjectAuthlib.cpp
+++ b/api/logic/minecraft/launch/InjectAuthlib.cpp
@@ -18,6 +18,8 @@
 #include <minecraft/MinecraftInstance.h>
 #include <FileSystem.h>
 #include <Env.h>
+#include <Json.h>
+
 InjectAuthlib::InjectAuthlib(LaunchTask *parent, AuthlibInjectorPtr* injector) : LaunchStep(parent)
 {
   m_injector = injector;
@@ -81,17 +83,20 @@ void InjectAuthlib::onVersionDownloadSucceeded()
     return;
   }
 
-  auto downloadUrlValue = doc["download_url"];
-  if (!downloadUrlValue.isString())
+  QString downloadUrl;
+  try
+  {
+    downloadUrl = Json::requireString(doc.object(), "download_url");
+  }
+  catch (const JSONValidationError &e)
   {
     qCritical() << "Error while parsing JSON response from InjectorEndpoint download url is not string";
+    qCritical() << e.cause();
     qCritical() << data;
     jobPtr.reset();
     emitFailed("Error while parsing JSON response from InjectorEndpoint");
     return;
   }
-
-  QString downloadUrl = downloadUrlValue.toString();
 
   QFileInfo fi(downloadUrl);
   m_versionName = fi.fileName();

--- a/api/logic/minecraft/launch/InjectAuthlib.cpp
+++ b/api/logic/minecraft/launch/InjectAuthlib.cpp
@@ -113,7 +113,7 @@ void InjectAuthlib::onVersionDownloadSucceeded()
 
 void InjectAuthlib::onDownloadSucceeded()
 {
-  QString injector = QString("-javaagent:%1=%2").arg(QDir("injectors").absoluteFilePath(m_versionName)).arg("http://localhost:6000");
+  QString injector = QString("-javaagent:%1=%2").arg(QDir("injectors").absoluteFilePath(m_versionName)).arg(m_authServer);
 
   qDebug()
       << "Injecting " << injector;

--- a/api/logic/minecraft/launch/InjectAuthlib.h
+++ b/api/logic/minecraft/launch/InjectAuthlib.h
@@ -1,0 +1,63 @@
+/* Copyright 2013-2021 MultiMC Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <launch/LaunchStep.h>
+#include <QObjectPtr.h>
+#include <LoggedProcess.h>
+#include <java/JavaChecker.h>
+#include <net/Mode.h>
+#include <net/NetJob.h>
+
+struct AuthlibInjector
+{
+  QString javaArg;
+
+  AuthlibInjector(const QString arg)
+  {
+    javaArg = std::move(arg);
+    qDebug() << "NEW INJECTOR" << javaArg;
+  }
+};
+
+typedef std::shared_ptr<AuthlibInjector> AuthlibInjectorPtr;
+
+// FIXME: stupid. should be defined by the instance type? or even completely abstracted away...
+class InjectAuthlib : public LaunchStep
+{
+  Q_OBJECT
+public:
+  InjectAuthlib(LaunchTask *parent, AuthlibInjectorPtr *injector);
+  virtual ~InjectAuthlib(){};
+
+  void executeTask() override;
+  bool canAbort() const override;
+  void proceed() override;
+public slots:
+  bool abort() override;
+
+private slots:
+  void onVersionDownloadSucceeded();
+  void onDownloadSucceeded();
+  void onDownloadFailed(QString reason);
+
+private:
+  shared_qobject_ptr<Task> jobPtr;
+  bool m_aborted = false;
+
+  QString m_versionName;
+  AuthlibInjectorPtr *m_injector;
+};

--- a/api/logic/minecraft/launch/InjectAuthlib.h
+++ b/api/logic/minecraft/launch/InjectAuthlib.h
@@ -46,6 +46,12 @@ public:
   void executeTask() override;
   bool canAbort() const override;
   void proceed() override;
+
+  void setAuthServer(QString server)
+  {
+    m_authServer = server;
+  };
+
 public slots:
   bool abort() override;
 
@@ -59,5 +65,6 @@ private:
   bool m_aborted = false;
 
   QString m_versionName;
+  QString m_authServer;
   AuthlibInjectorPtr *m_injector;
 };

--- a/api/logic/minecraft/legacy/LegacyInstance.h
+++ b/api/logic/minecraft/legacy/LegacyInstance.h
@@ -112,7 +112,7 @@ public:
         return false;
     }
     shared_qobject_ptr<LaunchTask> createLaunchTask(
-            AuthSessionPtr account, MinecraftServerTargetPtr serverToJoin) override
+            AuthSessionPtr account, MinecraftServerTargetPtr serverToJoin, quint16 localAuthServerPort) override
     {
         return nullptr;
     }

--- a/application/LaunchController.cpp
+++ b/application/LaunchController.cpp
@@ -197,7 +197,7 @@ void LaunchController::launchInstance()
         return;
     }
 
-    m_launcher = m_instance->createLaunchTask(m_session, m_serverToJoin);
+    m_launcher = m_instance->createLaunchTask(m_session, m_serverToJoin, m_authserver->port());
     if (!m_launcher)
     {
         emitFailed(tr("Couldn't instantiate a launcher."));

--- a/application/LaunchController.h
+++ b/application/LaunchController.h
@@ -4,6 +4,7 @@
 #include <tools/BaseProfiler.h>
 
 #include "minecraft/launch/MinecraftServerTarget.h"
+#include "AuthServer.h"
 
 class InstanceWindow;
 class LaunchController: public Task
@@ -39,6 +40,10 @@ public:
     {
         m_serverToJoin = std::move(serverToJoin);
     }
+    void setAuthserver(std::shared_ptr<AuthServer> authserver)
+    {
+        m_authserver = authserver;
+    }
     QString id()
     {
         return m_instance->id();
@@ -65,4 +70,5 @@ private:
     AuthSessionPtr m_session;
     shared_qobject_ptr<LaunchTask> m_launcher;
     MinecraftServerTargetPtr m_serverToJoin;
+    std::shared_ptr<AuthServer> m_authserver;
 };

--- a/application/MultiMC.cpp
+++ b/application/MultiMC.cpp
@@ -54,6 +54,7 @@
 #include "tools/JProfiler.h"
 #include "tools/JVisualVM.h"
 #include "tools/MCEditTool.h"
+#include "AuthServer.h"
 
 #include <xdgicon.h>
 #include "settings/INISettingsObject.h"
@@ -722,6 +723,11 @@ MultiMC::MultiMC(int &argc, char **argv) : QApplication(argc, argv)
     // Create the MCEdit thing... why is this here?
     {
         m_mcedit.reset(new MCEditTool(m_settings));
+    }
+
+    {
+        m_authserver.reset(new AuthServer(this));
+        qDebug() << "<> Auth server started.";
     }
 
     connect(this, &MultiMC::aboutToQuit, [this](){

--- a/application/MultiMC.cpp
+++ b/application/MultiMC.cpp
@@ -1108,6 +1108,7 @@ bool MultiMC::launch(
         controller->setOnline(online);
         controller->setProfiler(profiler);
         controller->setServerToJoin(serverToJoin);
+        controller->setAuthserver(m_authserver);
         if(window)
         {
             controller->setParentWidget(window);

--- a/application/MultiMC.h
+++ b/application/MultiMC.h
@@ -195,7 +195,7 @@ private:
     std::shared_ptr<GenericPageProvider> m_globalSettingsProvider;
     std::map<QString, std::unique_ptr<ITheme>> m_themes;
     std::unique_ptr<MCEditTool> m_mcedit;
-    std::unique_ptr<AuthServer> m_authserver;
+    std::shared_ptr<AuthServer> m_authserver;
 
     QMap<QString, std::shared_ptr<BaseProfilerFactory>> m_profilers;
 

--- a/application/MultiMC.h
+++ b/application/MultiMC.h
@@ -34,6 +34,7 @@ class BaseDetachedToolFactory;
 class TranslationsModel;
 class ITheme;
 class MCEditTool;
+class AuthServer;
 class GAnalytics;
 
 #if defined(MMC)
@@ -194,6 +195,7 @@ private:
     std::shared_ptr<GenericPageProvider> m_globalSettingsProvider;
     std::map<QString, std::unique_ptr<ITheme>> m_themes;
     std::unique_ptr<MCEditTool> m_mcedit;
+    std::unique_ptr<AuthServer> m_authserver;
 
     QMap<QString, std::shared_ptr<BaseProfilerFactory>> m_profilers;
 

--- a/application/dialogs/LoginDialog.cpp
+++ b/application/dialogs/LoginDialog.cpp
@@ -47,6 +47,8 @@ void LoginDialog::accept()
         m_account->setLoginType("mojang");
     else if (ui->radioDummy->isChecked())
         m_account->setLoginType("dummy");
+    else if (ui->radioElyby->isChecked())
+        m_account->setLoginType("elyby");
     m_loginTask = m_account->login(nullptr, ui->passTextBox->text());
     connect(m_loginTask.get(), &Task::failed, this, &LoginDialog::onTaskFailed);
     connect(m_loginTask.get(), &Task::succeeded, this,

--- a/application/dialogs/LoginDialog.ui
+++ b/application/dialogs/LoginDialog.ui
@@ -81,6 +81,15 @@
         <bool>false</bool>
        </property>
       </widget>
+     </item><item>
+      <widget class="QRadioButton" name="radioElyby">
+       <property name="text">
+        <string>Ely.by</string>
+       </property>
+       <property name="checked">
+        <bool>false</bool>
+       </property>
+      </widget>
      </item>
     </layout>
    </item>

--- a/buildconfig/BuildConfig.h
+++ b/buildconfig/BuildConfig.h
@@ -68,11 +68,14 @@ public:
     QString RESOURCE_BASE = "https://resources.download.minecraft.net/";
     QString LIBRARY_BASE = "https://libraries.minecraft.net/";
     QString SKINS_BASE = "https://crafatar.com/skins/";
-    QString AUTH_BASE = "https://authserver.mojang.com/";
     QString MOJANG_STATUS_URL = "https://status.mojang.com/check";
     QString IMGUR_BASE_URL = "https://api.imgur.com/3/";
     QString FMLLIBS_BASE_URL = "https://files.multimc.org/fmllibs/";
     QString TRANSLATIONS_BASE_URL = "https://files.multimc.org/translations/";
+
+
+    QString AUTH_BASE_MOJANG = "https://authserver.mojang.com/";
+    QString AUTH_BASE_ELYBY = "https://authserver.ely.by/auth/";
 
     QString MODPACKSCH_API_BASE_URL = "https://api.modpacks.ch/";
 


### PR DESCRIPTION
This pull request introduces:
* authlib injector - replace mojang server with another
* local auth server -  emulate mojang server
* ely.by account support

We should use this authlib injector and local auth server so that people can connect to games hosted using multimc using direct connect (for  example when you use hamachi). Ely by accounts support added, login to account and login to server works