### PR TITLE
UI Improvement: Display account type

### DIFF
--- a/api/logic/minecraft/auth/MojangAccount.cpp
+++ b/api/logic/minecraft/auth/MojangAccount.cpp
@@ -194,6 +194,18 @@ QString MojangAccount::authEndpoint() const
     return BuildConfig.AUTH_BASE_MOJANG;
 }
 
+QString MojangAccount::displayLoginType() const
+{
+    if(m_loginType == "mojang")
+        return "Mojang";
+    if(m_loginType == "dummy")
+        return "Local";
+    if(m_loginType == "elyby")
+        return "Ely.by";
+
+    return "Unknown";
+}
+
 std::shared_ptr<YggdrasilTask> MojangAccount::login(AuthSessionPtr session, QString password)
 {
     Q_ASSERT(m_currentTask.get() == nullptr);

--- a/api/logic/minecraft/auth/MojangAccount.h
+++ b/api/logic/minecraft/auth/MojangAccount.h
@@ -141,7 +141,11 @@ public: /* queries */
     //! Returns whether the account is NotVerified, Verified or Online
     AccountStatus accountStatus() const;
 
+    //! Returns endpoint for authentication
     QString authEndpoint() const;
+
+    // ! Returns login type to display in account list or account chooser
+    QString displayLoginType() const;
 
 signals:
     /**

--- a/api/logic/minecraft/auth/MojangAccountList.cpp
+++ b/api/logic/minecraft/auth/MojangAccountList.cpp
@@ -194,6 +194,9 @@ QVariant MojangAccountList::data(const QModelIndex &index, int role) const
         case NameColumn:
             return account->username();
 
+        case TypeColumn:
+            return account->displayLoginType();
+
         default:
             return QVariant();
         }
@@ -229,6 +232,9 @@ QVariant MojangAccountList::headerData(int section, Qt::Orientation orientation,
         case NameColumn:
             return tr("Name");
 
+        case TypeColumn:
+            return tr("Account type");
+
         default:
             return QVariant();
         }
@@ -256,7 +262,7 @@ int MojangAccountList::rowCount(const QModelIndex &) const
 
 int MojangAccountList::columnCount(const QModelIndex &) const
 {
-    return 2;
+    return 3;
 }
 
 Qt::ItemFlags MojangAccountList::flags(const QModelIndex &index) const

--- a/api/logic/minecraft/auth/MojangAccountList.h
+++ b/api/logic/minecraft/auth/MojangAccountList.h
@@ -51,6 +51,9 @@ public:
 
         // Second column - Name
         NameColumn,
+
+        // Third column - account type
+        TypeColumn,
     };
 
     explicit MojangAccountList(QObject *parent = 0);

--- a/application/MainWindow.cpp
+++ b/application/MainWindow.cpp
@@ -996,16 +996,15 @@ void MainWindow::updateToolsMenu()
     ui->actionLaunchInstanceOffline->setMenu(launchOfflineMenu);
 }
 
-QString profileInUseFilter(const QString & profile, bool used)
+QString formatProfile(const QString & profileName,  const QString & loginType, bool used)
 {
+    QString textInBrackets = loginType;
     if(used)
     {
-        return profile + QObject::tr(" (in use)");
+        textInBrackets += ", in use";
     }
-    else
-    {
-        return profile;
-    }
+    return ((QString)"%1 (%2)").arg(profileName).arg(textInBrackets);
+    
 }
 
 void MainWindow::repopulateAccountsMenu()
@@ -1023,7 +1022,7 @@ void MainWindow::repopulateAccountsMenu()
         // this can be called before accountMenuButton exists
         if (profile != nullptr && accountMenuButton)
         {
-            auto profileLabel = profileInUseFilter(profile->name, active_account->isInUse());
+            auto profileLabel = formatProfile(profile->name, active_account->displayLoginType(), active_account->isInUse());
             accountMenuButton->setText(profileLabel);
         }
     }
@@ -1042,7 +1041,8 @@ void MainWindow::repopulateAccountsMenu()
             MojangAccountPtr account = accounts->at(i);
             for (auto profile : account->profiles())
             {
-                auto profileLabel = profileInUseFilter(profile.name, account->isInUse());
+                auto profileLabel = formatProfile(profile.name, account->displayLoginType(), account->isInUse());
+                qDebug() << "AAA" << profileLabel;
                 QAction *action = new QAction(profileLabel, this);
                 action->setData(account->username());
                 action->setCheckable(true);
@@ -1119,7 +1119,7 @@ void MainWindow::activeAccountChanged()
         const AccountProfile *profile = account->currentProfile();
         if (profile != nullptr)
         {
-            auto profileLabel = profileInUseFilter(profile->name, account->isInUse());
+            auto profileLabel = formatProfile(profile->name, account->displayLoginType(), account->isInUse());
             accountMenuButton->setIcon(SkinUtils::getFaceFromCache(profile->id));
             accountMenuButton->setText(profileLabel);
             return;

--- a/application/dialogs/LoginDialog.ui
+++ b/application/dialogs/LoginDialog.ui
@@ -75,7 +75,7 @@
      <item>
       <widget class="QRadioButton" name="radioDummy">
        <property name="text">
-        <string>Offline (cracked)</string>
+        <string>Local (cracked)</string>
        </property>
        <property name="checked">
         <bool>false</bool>

--- a/application/pages/global/AccountListPage.cpp
+++ b/application/pages/global/AccountListPage.cpp
@@ -143,9 +143,11 @@ void AccountListPage::updateButtonStates()
 
     ui->actionRemove->setEnabled(selection.size() > 0);
     ui->actionSetDefault->setEnabled(selection.size() > 0);
-    ui->actionUploadSkin->setEnabled(selection.size() > 0);
-    ui->actionDeleteSkin->setEnabled(selection.size() > 0);
 
+    bool enableSkins = selection.size() > 0 && selection.first().data(MojangAccountList::PointerRole).value<MojangAccountPtr>()->loginType() == "mojang";
+    ui->actionUploadSkin->setEnabled(enableSkins);
+    ui->actionDeleteSkin->setEnabled(enableSkins);
+    
     if(m_accounts->activeAccount().get() == nullptr) {
         ui->actionNoDefault->setEnabled(false);
         ui->actionNoDefault->setChecked(true);

--- a/application/pages/global/AccountListPage.cpp
+++ b/application/pages/global/AccountListPage.cpp
@@ -55,6 +55,7 @@ AccountListPage::AccountListPage(QWidget *parent)
 
     // Expand the account column
     ui->listView->header()->setSectionResizeMode(1, QHeaderView::Stretch);
+    ui->listView->header()->setSectionResizeMode(2, QHeaderView::Stretch);
 
     QItemSelectionModel *selectionModel = ui->listView->selectionModel();
 


### PR DESCRIPTION
This pull request introduces:
* displaying of account type in account list and account selector
![Screenshot_20210610_204759](https://user-images.githubusercontent.com/25984188/121572752-2e0ee800-ca2d-11eb-8185-fb1c4a70be8a.png)
![Screenshot_20210610_204835](https://user-images.githubusercontent.com/25984188/121573010-6b737580-ca2d-11eb-862d-155402c6567a.png)
* disabling of `Upload skin` and `Delete skin` when account type is not mojang
* renaming of `Offline (cracked)` into `Local (cracked)` because accounts of this type work in online servers