### PR TITLE
Remove Anti-WSL (Windows Subsystem for Linux) code

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,14 +5,9 @@ if(IS_IN_SOURCE_BUILD)
     message(FATAL_ERROR "You are building MultiMC in-source. Please separate the build tree from the source tree.")
 endif()
 
-if (CMAKE_SYSTEM_NAME STREQUAL "Linux")
-    if(CMAKE_HOST_SYSTEM_VERSION MATCHES ".*[Mm]icrosoft.*" OR
-        CMAKE_HOST_SYSTEM_VERSION MATCHES ".*WSL.*"
-    )
-        message(FATAL_ERROR "Building MultiMC is not supported in Linux-on-Windows distributions.")
-    endif()
-endif()
-
+######
+# Remove WSL CMake check that doesn't even work anyway
+######
 if(WIN32)
     # In Qt 5.1+ we have our own main() function, don't autolink to qtmain on Windows
     cmake_policy(SET CMP0020 OLD)

--- a/launcher/MultiMC.cpp
+++ b/launcher/MultiMC.cpp
@@ -189,22 +189,7 @@ MultiMC::MultiMC(int &argc, char **argv) : QApplication(argc, argv)
 
 #ifdef Q_OS_LINUX
     {
-        QFile osrelease("/proc/sys/kernel/osrelease");
-        if (osrelease.open(QFile::ReadOnly | QFile::Text)) {
-            QTextStream in(&osrelease);
-            auto contents = in.readAll();
-            if(
-                contents.contains("WSL", Qt::CaseInsensitive) ||
-                contents.contains("Microsoft", Qt::CaseInsensitive)
-            ) {
-                showFatalErrorMessage(
-                    "Unsupported system detected!",
-                    "Linux-on-Windows distributions are not supported.\n\n"
-                    "Please use the Windows MultiMC binary when playing on Windows."
-                );
-                return;
-            }
-        }
+    
     }
 #endif
 

--- a/launcher/MultiMC.cpp
+++ b/launcher/MultiMC.cpp
@@ -188,9 +188,7 @@ MultiMC::MultiMC(int &argc, char **argv) : QApplication(argc, argv)
     startTime = QDateTime::currentDateTime();
 
 #ifdef Q_OS_LINUX
-    {
-    
-    }
+    // Remove anti-WSL check at runtime
 #endif
 
     // Don't quit on hiding the last window

--- a/libraries/katabasis/CMakeLists.txt
+++ b/libraries/katabasis/CMakeLists.txt
@@ -6,11 +6,7 @@ if(IS_IN_SOURCE_BUILD)
 endif()
 
 if (CMAKE_SYSTEM_NAME STREQUAL "Linux")
-    if(CMAKE_HOST_SYSTEM_VERSION MATCHES ".*[Mm]icrosoft.*" OR
-        CMAKE_HOST_SYSTEM_VERSION MATCHES ".*WSL.*"
-    )
-        message(FATAL_ERROR "Building Katabasis is not supported in Linux-on-Windows distributions. Use a real Linux machine, not a fraudulent one.")
-    endif()
+    
 endif()
 
 project(Katabasis)

--- a/libraries/katabasis/CMakeLists.txt
+++ b/libraries/katabasis/CMakeLists.txt
@@ -5,9 +5,9 @@ if(IS_IN_SOURCE_BUILD)
     message(FATAL_ERROR "You are building Katabasis in-source. Please separate the build tree from the source tree.")
 endif()
 
-if (CMAKE_SYSTEM_NAME STREQUAL "Linux")
-    
-endif()
+####################
+## Remove WSL check 
+############
 
 project(Katabasis)
 enable_testing()


### PR DESCRIPTION
This will allow MultiMC5-cracked to compile and run on WSL. Highly doubt I can get this through upstream, so this is the next best option here.

Not exactly the most useful request here but it's nice if you like the 10 FPS experience or if you're bored, especially since WSLg is built into Windows 11 now.